### PR TITLE
Spelling Citation - Credentails -> Credentials

### DIFF
--- a/credentials/README.md
+++ b/credentials/README.md
@@ -10,7 +10,7 @@ Currently, this package supports `grant type` of password OAuth flow.  The packa
 The following are some example(s) of creating credentials to be used when opening a session.
 ### Password
 ```go
-creds := credentials.PasswordCredentails{
+creds := credentials.PasswordCredentials{
 	URL:          "https://login.salesforce.com",
 	Username:     "my.user@name.com",
 	Password:     "greatpassword",

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-// PasswordCredentails is a structure for the OAuth credentials
+// PasswordCredentials is a structure for the OAuth credentials
 // that are needed to authenticate with a Salesforce org.
 //
 // URL is the login URL used, examples would be https://test.salesforce.com or https://login.salesforce.com
@@ -17,7 +17,7 @@ import (
 // ClientID is the client ID from the connected application.
 //
 // ClientSecret is the client secret from the connected application.
-type PasswordCredentails struct {
+type PasswordCredentials struct {
 	URL          string
 	Username     string
 	Password     string
@@ -69,8 +69,8 @@ func NewCredentials(provider Provider) (*Credentials, error) {
 }
 
 // NewPasswordCredentials will create a crendential with the password credentials.
-func NewPasswordCredentials(creds PasswordCredentails) (*Credentials, error) {
-	if err := validatePasswordCredentails(creds); err != nil {
+func NewPasswordCredentials(creds PasswordCredentials) (*Credentials, error) {
+	if err := validatePasswordCredentials(creds); err != nil {
 		return nil, err
 	}
 	return &Credentials{
@@ -80,21 +80,21 @@ func NewPasswordCredentials(creds PasswordCredentails) (*Credentials, error) {
 	}, nil
 }
 
-func validatePasswordCredentails(cred PasswordCredentails) error {
+func validatePasswordCredentials(cred PasswordCredentials) error {
 	if cred.URL == "" {
-		return errors.New("credentials: password credentail's URL can not be empty")
+		return errors.New("credentials: password credentials's URL can not be empty")
 	}
 	if cred.Username == "" {
-		return errors.New("credentials: password credentail's username can not be empty")
+		return errors.New("credentials: password credentials's username can not be empty")
 	}
 	if cred.Password == "" {
-		return errors.New("credentials: password credentail's password can not be empty")
+		return errors.New("credentials: password credentials's password can not be empty")
 	}
 	if cred.ClientID == "" {
-		return errors.New("credentials: password credentail's client ID can not be empty")
+		return errors.New("credentials: password credentials's client ID can not be empty")
 	}
 	if cred.ClientSecret == "" {
-		return errors.New("credentials: password credentail's client secret can not be empty")
+		return errors.New("credentials: password credentials's client secret can not be empty")
 	}
 	return nil
 }

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -82,19 +82,19 @@ func NewPasswordCredentials(creds PasswordCredentials) (*Credentials, error) {
 
 func validatePasswordCredentials(cred PasswordCredentials) error {
 	if cred.URL == "" {
-		return errors.New("credentials: password credentials's URL can not be empty")
+		return errors.New("credentials: password credential's URL can not be empty")
 	}
 	if cred.Username == "" {
-		return errors.New("credentials: password credentials's username can not be empty")
+		return errors.New("credentials: password credential's username can not be empty")
 	}
 	if cred.Password == "" {
-		return errors.New("credentials: password credentials's password can not be empty")
+		return errors.New("credentials: password credential's password can not be empty")
 	}
 	if cred.ClientID == "" {
-		return errors.New("credentials: password credentials's client ID can not be empty")
+		return errors.New("credentials: password credential's client ID can not be empty")
 	}
 	if cred.ClientSecret == "" {
-		return errors.New("credentials: password credentials's client secret can not be empty")
+		return errors.New("credentials: password credential's client secret can not be empty")
 	}
 	return nil
 }

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewPasswordCredentials(t *testing.T) {
 	type args struct {
-		creds PasswordCredentails
+		creds PasswordCredentials
 	}
 	tests := []struct {
 		name    string
@@ -21,7 +21,7 @@ func TestNewPasswordCredentials(t *testing.T) {
 		{
 			name: "Password Credentials",
 			args: args{
-				creds: PasswordCredentails{
+				creds: PasswordCredentials{
 					URL:          "http://test.password.session",
 					Username:     "myusername",
 					Password:     "12345",
@@ -31,7 +31,7 @@ func TestNewPasswordCredentials(t *testing.T) {
 			},
 			want: &Credentials{
 				provider: &passwordProvider{
-					creds: PasswordCredentails{
+					creds: PasswordCredentials{
 						URL:          "http://test.password.session",
 						Username:     "myusername",
 						Password:     "12345",
@@ -45,7 +45,7 @@ func TestNewPasswordCredentials(t *testing.T) {
 		{
 			name: "No URL",
 			args: args{
-				creds: PasswordCredentails{
+				creds: PasswordCredentials{
 					URL:          "",
 					Username:     "myusername",
 					Password:     "12345",
@@ -59,7 +59,7 @@ func TestNewPasswordCredentials(t *testing.T) {
 		{
 			name: "No Username",
 			args: args{
-				creds: PasswordCredentails{
+				creds: PasswordCredentials{
 					URL:          "http://test.password.session",
 					Username:     "",
 					Password:     "12345",
@@ -73,7 +73,7 @@ func TestNewPasswordCredentials(t *testing.T) {
 		{
 			name: "No password",
 			args: args{
-				creds: PasswordCredentails{
+				creds: PasswordCredentials{
 					URL:          "http://test.password.session",
 					Username:     "myusername",
 					Password:     "",
@@ -87,7 +87,7 @@ func TestNewPasswordCredentials(t *testing.T) {
 		{
 			name: "No client ID",
 			args: args{
-				creds: PasswordCredentails{
+				creds: PasswordCredentials{
 					URL:          "http://test.password.session",
 					Username:     "myusername",
 					Password:     "12345",
@@ -101,7 +101,7 @@ func TestNewPasswordCredentials(t *testing.T) {
 		{
 			name: "No client secret",
 			args: args{
-				creds: PasswordCredentails{
+				creds: PasswordCredentials{
 					URL:          "http://test.password.session",
 					Username:     "myusername",
 					Password:     "12345",
@@ -142,7 +142,7 @@ func TestNewCredentials(t *testing.T) {
 			name: "New Credentials",
 			args: args{
 				provider: &passwordProvider{
-					creds: PasswordCredentails{
+					creds: PasswordCredentials{
 						URL:          "http://test.password.session",
 						Username:     "myusername",
 						Password:     "12345",
@@ -153,7 +153,7 @@ func TestNewCredentials(t *testing.T) {
 			},
 			want: &Credentials{
 				provider: &passwordProvider{
-					creds: PasswordCredentails{
+					creds: PasswordCredentials{
 						URL:          "http://test.password.session",
 						Username:     "myusername",
 						Password:     "12345",
@@ -199,7 +199,7 @@ func TestCredentials_URL(t *testing.T) {
 			name: "Credential URL",
 			fields: fields{
 				provider: &passwordProvider{
-					creds: PasswordCredentails{
+					creds: PasswordCredentials{
 						URL:          "http://test.password.session",
 						Username:     "myusername",
 						Password:     "12345",
@@ -223,7 +223,7 @@ func TestCredentials_URL(t *testing.T) {
 	}
 }
 
-func mockCredentialsRetriveReader(creds PasswordCredentails) io.Reader {
+func mockCredentialsRetriveReader(creds PasswordCredentials) io.Reader {
 	form := url.Values{}
 	form.Add("grant_type", string(passwordGrantType))
 	form.Add("username", creds.Username)
@@ -249,7 +249,7 @@ func TestCredentials_Retrieve(t *testing.T) {
 			name: "Credential Retrieve",
 			fields: fields{
 				provider: &passwordProvider{
-					creds: PasswordCredentails{
+					creds: PasswordCredentials{
 						URL:          "http://test.password.session",
 						Username:     "myusername",
 						Password:     "12345",
@@ -258,7 +258,7 @@ func TestCredentials_Retrieve(t *testing.T) {
 					},
 				},
 			},
-			want: mockCredentialsRetriveReader(PasswordCredentails{
+			want: mockCredentialsRetriveReader(PasswordCredentials{
 				URL:          "http://test.password.session",
 				Username:     "myusername",
 				Password:     "12345",

--- a/credentials/password.go
+++ b/credentials/password.go
@@ -7,7 +7,7 @@ import (
 )
 
 type passwordProvider struct {
-	creds PasswordCredentails
+	creds PasswordCredentials
 }
 
 func (provider *passwordProvider) Retrieve() (io.Reader, error) {

--- a/credentials/password_test.go
+++ b/credentials/password_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func mockPasswordRetriveReader(creds PasswordCredentails) io.Reader {
+func mockPasswordRetriveReader(creds PasswordCredentials) io.Reader {
 	form := url.Values{}
 	form.Add("grant_type", string(passwordGrantType))
 	form.Add("username", creds.Username)
@@ -20,7 +20,7 @@ func mockPasswordRetriveReader(creds PasswordCredentails) io.Reader {
 }
 func Test_passwordProvider_Retrieve(t *testing.T) {
 	type fields struct {
-		creds PasswordCredentails
+		creds PasswordCredentials
 	}
 	tests := []struct {
 		name    string
@@ -32,7 +32,7 @@ func Test_passwordProvider_Retrieve(t *testing.T) {
 		{
 			name: "Password Retriever",
 			fields: fields{
-				creds: PasswordCredentails{
+				creds: PasswordCredentials{
 					URL:          "http://test.password.session",
 					Username:     "myusername",
 					Password:     "12345",
@@ -40,7 +40,7 @@ func Test_passwordProvider_Retrieve(t *testing.T) {
 					ClientSecret: "shhhh its a secret",
 				},
 			},
-			want: mockPasswordRetriveReader(PasswordCredentails{
+			want: mockPasswordRetriveReader(PasswordCredentials{
 				URL:          "http://test.password.session",
 				Username:     "myusername",
 				Password:     "12345",
@@ -69,7 +69,7 @@ func Test_passwordProvider_Retrieve(t *testing.T) {
 
 func Test_passwordProvider_URL(t *testing.T) {
 	type fields struct {
-		creds PasswordCredentails
+		creds PasswordCredentials
 	}
 	tests := []struct {
 		name   string
@@ -79,7 +79,7 @@ func Test_passwordProvider_URL(t *testing.T) {
 		{
 			name: "Password URL",
 			fields: fields{
-				creds: PasswordCredentails{
+				creds: PasswordCredentials{
 					URL:          "http://test.password.session",
 					Username:     "myusername",
 					Password:     "12345",

--- a/session/README.md
+++ b/session/README.md
@@ -6,7 +6,7 @@ The session is used to authenticate with `Salesforce` and retrieve the org's inf
 ## Example
 The following example demonstrates how to create a session.
 ```go
-pwdCreds, err := credentials.NewPasswordCredentials(credentials.PasswordCredentails{
+pwdCreds, err := credentials.NewPasswordCredentials(credentials.PasswordCredentials{
 	URL:          "https://login.salesforce.com",
 	Username:     "my.user@name.com",
 	Password:     "greatpassword",

--- a/session/session.go
+++ b/session/session.go
@@ -60,7 +60,7 @@ type sessionPasswordResponse struct {
 const oauthEndpoint = "/services/oauth2/token"
 
 // Open is used to authenticate with Salesforce and open a session.  The user will need to
-// supply the proper credentails and a HTTP client.
+// supply the proper credentialss and a HTTP client.
 func Open(config sfdc.Configuration) (*Session, error) {
 	if config.Credentials == nil {
 		return nil, errors.New("session: configuration crendentials can not be nil")

--- a/session/session.go
+++ b/session/session.go
@@ -60,7 +60,7 @@ type sessionPasswordResponse struct {
 const oauthEndpoint = "/services/oauth2/token"
 
 // Open is used to authenticate with Salesforce and open a session.  The user will need to
-// supply the proper credentialss and a HTTP client.
+// supply the proper credentials and a HTTP client.
 func Open(config sfdc.Configuration) (*Session, error) {
 	if config.Credentials == nil {
 		return nil, errors.New("session: configuration crendentials can not be nil")

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -17,12 +17,12 @@ func TestPasswordSessionRequest(t *testing.T) {
 
 	scenarios := []struct {
 		desc  string
-		creds credentials.PasswordCredentails
+		creds credentials.PasswordCredentials
 		err   error
 	}{
 		{
 			desc: "Passing HTTP request",
-			creds: credentials.PasswordCredentails{
+			creds: credentials.PasswordCredentials{
 				URL:          "http://test.password.session",
 				Username:     "myusername",
 				Password:     "12345",
@@ -33,7 +33,7 @@ func TestPasswordSessionRequest(t *testing.T) {
 		},
 		{
 			desc: "Bad URL",
-			creds: credentials.PasswordCredentails{
+			creds: credentials.PasswordCredentials{
 				URL:          "123://something.com",
 				Username:     "myusername",
 				Password:     "12345",
@@ -220,7 +220,7 @@ func TestPasswordSessionResponse(t *testing.T) {
 	}
 }
 
-func testNewPasswordCredentials(cred credentials.PasswordCredentails) *credentials.Credentials {
+func testNewPasswordCredentials(cred credentials.PasswordCredentials) *credentials.Credentials {
 	creds, err := credentials.NewPasswordCredentials(cred)
 	if err != nil {
 		return nil
@@ -237,7 +237,7 @@ func TestNewPasswordSession(t *testing.T) {
 		{
 			desc: "Passing",
 			config: sfdc.Configuration{
-				Credentials: testNewPasswordCredentials(credentials.PasswordCredentails{
+				Credentials: testNewPasswordCredentials(credentials.PasswordCredentials{
 					URL:          "http://test.password.session",
 					Username:     "myusername",
 					Password:     "12345",
@@ -279,7 +279,7 @@ func TestNewPasswordSession(t *testing.T) {
 		{
 			desc: "Error Request",
 			config: sfdc.Configuration{
-				Credentials: testNewPasswordCredentials(credentials.PasswordCredentails{
+				Credentials: testNewPasswordCredentials(credentials.PasswordCredentials{
 					URL:          "123://test.password.session",
 					Username:     "myusername",
 					Password:     "12345",
@@ -300,7 +300,7 @@ func TestNewPasswordSession(t *testing.T) {
 		{
 			desc: "Error Response",
 			config: sfdc.Configuration{
-				Credentials: testNewPasswordCredentials(credentials.PasswordCredentails{
+				Credentials: testNewPasswordCredentials(credentials.PasswordCredentials{
 					URL:          "http://test.password.session",
 					Username:     "myusername",
 					Password:     "12345",


### PR DESCRIPTION
## What does this solve?
* Resolves a spelling error where many places spelled `Credentials` as `Credentails`.

## Is there anything particularly tricky?
No.