### PR TITLE
Added back the response body close statements

### DIFF
--- a/bulk/job.go
+++ b/bulk/job.go
@@ -353,6 +353,7 @@ func (j *Job) Delete() error {
 	if err != nil {
 		return err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusNoContent {
 		return errors.New("job error: unable to delete job")
@@ -374,6 +375,7 @@ func (j *Job) Upload(body io.Reader) error {
 	if err != nil {
 		return err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusCreated {
 		return errors.New("job error: unable to upload job")
@@ -395,10 +397,10 @@ func (j *Job) SuccessfulRecords() ([]SuccessfulRecord, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		decoder := json.NewDecoder(response.Body)
-		defer response.Body.Close()
 		var errs []sfdc.Error
 		err = decoder.Decode(&errs)
 		var errMsg error
@@ -413,7 +415,6 @@ func (j *Job) SuccessfulRecords() ([]SuccessfulRecord, error) {
 	}
 
 	scanner := bufio.NewScanner(response.Body)
-	defer response.Body.Close()
 	scanner.Split(bufio.ScanLines)
 	var records []SuccessfulRecord
 	delimiter := j.delimiter()
@@ -461,10 +462,10 @@ func (j *Job) FailedRecords() ([]FailedRecord, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		decoder := json.NewDecoder(response.Body)
-		defer response.Body.Close()
 		var errs []sfdc.Error
 		err = decoder.Decode(&errs)
 		var errMsg error
@@ -479,7 +480,6 @@ func (j *Job) FailedRecords() ([]FailedRecord, error) {
 	}
 
 	scanner := bufio.NewScanner(response.Body)
-	defer response.Body.Close()
 	scanner.Split(bufio.ScanLines)
 	var records []FailedRecord
 	delimiter := j.delimiter()
@@ -522,10 +522,10 @@ func (j *Job) UnprocessedRecords() ([]UnprocessedRecord, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		decoder := json.NewDecoder(response.Body)
-		defer response.Body.Close()
 		var errs []sfdc.Error
 		err = decoder.Decode(&errs)
 		var errMsg error
@@ -540,7 +540,6 @@ func (j *Job) UnprocessedRecords() ([]UnprocessedRecord, error) {
 	}
 
 	scanner := bufio.NewScanner(response.Body)
-	defer response.Body.Close()
 	scanner.Split(bufio.ScanLines)
 	var records []UnprocessedRecord
 	delimiter := j.delimiter()

--- a/sobject/dml.go
+++ b/sobject/dml.go
@@ -192,9 +192,10 @@ func (d *dml) updateResponse(request *http.Request) error {
 		return err
 	}
 
+	defer response.Body.Close()
+
 	if response.StatusCode != http.StatusNoContent {
 		decoder := json.NewDecoder(response.Body)
-		defer response.Body.Close()
 
 		var updateErrs []sfdc.Error
 		err = decoder.Decode(&updateErrs)
@@ -256,6 +257,8 @@ func (d *dml) upsertResponse(request *http.Request) (UpsertValue, error) {
 		return UpsertValue{}, err
 	}
 
+	defer response.Body.Close()
+
 	decoder := json.NewDecoder(response.Body)
 
 	var isInsert bool
@@ -263,7 +266,6 @@ func (d *dml) upsertResponse(request *http.Request) (UpsertValue, error) {
 
 	switch response.StatusCode {
 	case http.StatusCreated:
-		defer response.Body.Close()
 		isInsert = true
 		err = decoder.Decode(&value)
 		if err != nil {
@@ -272,7 +274,6 @@ func (d *dml) upsertResponse(request *http.Request) (UpsertValue, error) {
 	case http.StatusNoContent:
 		isInsert = false
 	default:
-		defer response.Body.Close()
 		var upsetErrs []sfdc.Error
 		err = decoder.Decode(&upsetErrs)
 		errMsg := fmt.Errorf("upsert response err: %d %s", response.StatusCode, response.Status)
@@ -319,6 +320,8 @@ func (d *dml) deleteResponse(request *http.Request) error {
 	if err != nil {
 		return err
 	}
+
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("delete has failed %d %s", response.StatusCode, response.Status)

--- a/sobject/query.go
+++ b/sobject/query.go
@@ -347,13 +347,13 @@ func (q *query) contentResponse(request *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("deleted records response err: %d %s", response.StatusCode, response.Status)
 	}
 
 	body, err := ioutil.ReadAll(response.Body)
-	defer response.Body.Close()
 
 	return body, err
 }


### PR DESCRIPTION
During some re-working of this repo, this code change was lost. This is brining back the `defer response.Body.Close` 

https://github.com/TheJumpCloud/go-sfdc/pull/7